### PR TITLE
Add force to temporary file removal to enable headless usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ If you make changes after importing, use ``Import-Module -Force`` to make those 
 #### Manual Installation ####
 
 To manually install released or development versions of PoShTeX, we must copy the files comprising PoShTeX to a directory matching PowerShell's naming conventions.
-In particular, by default, PowerShell looks for PoShTeX version 0.1.7 in the following folders:
+In particular, by default, PowerShell looks for PoShTeX version 0.1.7.4 in the following folders:
 
-- **Windows**: ``~\Documents\WindowsPowerShell\Modules\posh-tex\0.1.7``
-- **Linux**: ``~/.local/share/powershell/Modules/posh-tex/0.1.7``
+- **Windows**: ``~\Documents\WindowsPowerShell\Modules\posh-tex\0.1.7.4``
+- **Linux**: ``~/.local/share/powershell/Modules/posh-tex/0.1.7.4``
 - **macOS / OS X**: TODO
 
 Unfortunately, there's not currently an easy-to-use automated way to find the appropriate path, but for now, so modify the instructions below as needed if you have changed your ``$Env:PSModulePath`` environment variable to look somewhere other than the defaults above.
 
 ```
-PS> Copy-Item -Recurse src/ ~/.local/share/powershell/Modules/posh-tex/0.1.7
+PS> Copy-Item -Recurse src/ ~/.local/share/powershell/Modules/posh-tex/0.1.7.4
 ```
 
 **NB**: If the version number in your installation path does not match the version number in ``src/posh-tex.psd1``, PowerShell will silently ignore your installation when you run ``Import-Module posh-tex``.

--- a/docs/cmdlets/Export-ArXivArchive.md
+++ b/docs/cmdlets/Export-ArXivArchive.md
@@ -25,8 +25,8 @@ Prepares a ZIP archive of a LaTeX-based project suitable for uploading to arXiv.
 #region Bootstrap PoShTeX
 $modules = Get-Module -ListAvailable -Name posh-tex;
 if (!$modules) {Install-Module posh-tex -Scope CurrentUser}
-if (!($modules | ? {$_.Version -ge "0.1.7"})) {Update-Module posh-tex}
-Import-Module posh-tex -Version "0.1.7"
+if (!($modules | ? {$_.Version -ge "0.1.7.4"})) {Update-Module posh-tex}
+Import-Module posh-tex -Version "0.1.7.4"
 #endregion
 
 Export-ArXivArchive @{

--- a/src/cmdlets/ArXiv.ps1
+++ b/src/cmdlets/ArXiv.ps1
@@ -180,7 +180,12 @@ function Export-ArXivArchive {
 
         # Before popping out of the temporary build directory, we need to clean
         # it up.
-        Get-ChildItem -Recurse -Exclude $tempDirContents | Remove-Item;
+        # Use -Force to enable using posh-tex in non-interactive environments.
+        $newContents = Get-ChildItem -Recurse;
+        Compare-Object $tempDirContents $newContents `
+            | Where-Object { $_.SideIndicator -eq "=>" } `
+            | Select-Object -ExpandProperty InputObject `
+            | Remove-Item -Force -Confirm:$false -Verbose;
     Pop-Location;
 
     $archiveName = "./$($ExpandedManifest["ProjectName"]).zip"

--- a/src/posh-tex.psd1
+++ b/src/posh-tex.psd1
@@ -37,7 +37,7 @@
 RootModule = 'posh-tex.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.7'
+ModuleVersion = '0.1.7.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Linux and Windows handle the `-Exclude` parameter of `Get-ChildItem` a bit differently, so it's more robust to go through `Compare-Object`.